### PR TITLE
URL Cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv="refresh" content="0;url=http://platform.spring.io/platform" />
+  <meta http-equiv="refresh" content="0;url=https://platform.spring.io/platform" />
 </head>
 </html>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://platform.spring.io/platform with 1 occurrences migrated to:  
  https://platform.spring.io/platform ([https](https://platform.spring.io/platform) result 301).